### PR TITLE
Add null-check for request before checking SelectedItem on global search

### DIFF
--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -204,7 +204,7 @@ namespace BH.UI.Grasshopper.Global
 
                     componentCreated = canvas.InstantiateNewObject(node.Id, initCode, canvas.CursorCanvasPosition, true);
                 }
-                else if (request.SelectedItem is CustomItem)
+                else if (request?.SelectedItem is CustomItem)
                 {
                     CustomItem item = request.SelectedItem as CustomItem;
                     if (item != null && item.Content is IGH_ObjectProxy)


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #675

<!-- Add short description of what has been fixed -->

Adding simple null-check on request before trying to access SelectedItem.
See issue as to why/when this has been slightly annoying issue.


### Test files
<!-- Link to test files to validate the proposed changes -->

Global search should still work.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Cannot really see how this could have a negative impact on anything, but glad for a quick look @adecler 