### PR TITLE
Changed namespace for BH.Engine.Rhinoceros

### DIFF
--- a/Grasshopper_Engine/Convert/ToNode.cs
+++ b/Grasshopper_Engine/Convert/ToNode.cs
@@ -20,7 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;

--- a/Grasshopper_Engine/Convert/ToNodeGroup.cs
+++ b/Grasshopper_Engine/Convert/ToNodeGroup.cs
@@ -20,7 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;

--- a/Grasshopper_Engine/Convert/ToNodeParam.cs
+++ b/Grasshopper_Engine/Convert/ToNodeParam.cs
@@ -20,7 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;

--- a/Grasshopper_Engine/Convert/ToRhino.cs
+++ b/Grasshopper_Engine/Convert/ToRhino.cs
@@ -21,7 +21,7 @@
  */
 
 using BH.Engine.Base;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
@@ -43,7 +43,7 @@ namespace BH.Engine.Grasshopper
             {
                 if (x == null)
                     return null;
-                else if (BH.Engine.Rhinoceros.Query.IsRhinoEquivalent(x.GetType()))
+                else if (BH.Engine.Adapters.Rhinoceros.Query.IsRhinoEquivalent(x.GetType()))
                     return ((IGeometry)x).IToRhino();
                 else
                     return x;

--- a/Grasshopper_Engine/Convert/ToType.cs
+++ b/Grasshopper_Engine/Convert/ToType.cs
@@ -20,7 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;

--- a/Grasshopper_UI/Goos/GH_BHoMObject.cs
+++ b/Grasshopper_UI/Goos/GH_BHoMObject.cs
@@ -27,7 +27,7 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using System;
 using BH.Engine.Base;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using Rhino;
 using Rhino.DocObjects;
 using GH_IO;

--- a/Grasshopper_UI/Goos/GH_BakeableObject.cs
+++ b/Grasshopper_UI/Goos/GH_BakeableObject.cs
@@ -27,7 +27,7 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using System;
 using BH.Engine.Base;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using Rhino;
 using Rhino.DocObjects;
 using GH_IO;
@@ -110,7 +110,7 @@ namespace BH.UI.Grasshopper.Goos
                 return CastFrom(Helpers.IFromGoo<T>((IGH_Goo)source));
 
             if (source.GetType().Namespace.StartsWith("Rhino.Geometry"))
-                source = BH.Engine.Rhinoceros.Convert.IFromRhino(source);
+                source = BH.Engine.Adapters.Rhinoceros.Convert.IFromRhino(source);
 
             return base.CastFrom(source);
         }

--- a/Grasshopper_UI/Goos/GH_IBHoMGeometry.cs
+++ b/Grasshopper_UI/Goos/GH_IBHoMGeometry.cs
@@ -25,7 +25,7 @@ using Grasshopper.Kernel.Types;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using System;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using Rhino;
 using Rhino.DocObjects;
 using GH_IO.Serialization;

--- a/Grasshopper_UI/Goos/GH_IObject.cs
+++ b/Grasshopper_UI/Goos/GH_IObject.cs
@@ -27,7 +27,7 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using System;
 using BH.Engine.Base;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using Rhino;
 using Rhino.DocObjects;
 using GH_IO;

--- a/Grasshopper_UI/Goos/GH_Variable.cs
+++ b/Grasshopper_UI/Goos/GH_Variable.cs
@@ -27,7 +27,7 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using System;
 using BH.Engine.Base;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using Rhino;
 using Rhino.DocObjects;
 using GH_IO;

--- a/Grasshopper_UI/Helpers/FromGoo.cs
+++ b/Grasshopper_UI/Helpers/FromGoo.cs
@@ -63,7 +63,7 @@ namespace BH.UI.Grasshopper
                 return default(T);
 
             if (data.GetType().Namespace.StartsWith("Rhino.Geometry") && !typeof(T).Namespace.StartsWith("Rhino.Geometry"))
-                data = BH.Engine.Rhinoceros.Convert.IFromRhino(data);
+                data = BH.Engine.Adapters.Rhinoceros.Convert.IFromRhino(data);
 
             // Convert the data to an acceptable format
             if (hint != null)
@@ -73,7 +73,7 @@ namespace BH.UI.Grasshopper
                 data = result;
 
                 if (data.GetType().Namespace.StartsWith("Rhino.Geometry") && !typeof(T).Namespace.StartsWith("Rhino.Geometry"))
-                    data = BH.Engine.Rhinoceros.Convert.IFromRhino(data);
+                    data = BH.Engine.Adapters.Rhinoceros.Convert.IFromRhino(data);
             }
             else if (data is T)
             {
@@ -111,9 +111,9 @@ namespace BH.UI.Grasshopper
 
             oM.Geometry.IGeometry geometry = null;
             if (brep.IsSurface)
-                geometry = BH.Engine.Rhinoceros.Convert.IFromRhino(brep.Faces[0].UnderlyingSurface());
+                geometry = BH.Engine.Adapters.Rhinoceros.Convert.IFromRhino(brep.Faces[0].UnderlyingSurface());
             else
-                geometry = BH.Engine.Rhinoceros.Convert.IFromRhino(brep);
+                geometry = BH.Engine.Adapters.Rhinoceros.Convert.IFromRhino(brep);
 
             try
             {

--- a/Grasshopper_UI/Render/CreatePreviewMesh.cs
+++ b/Grasshopper_UI/Render/CreatePreviewMesh.cs
@@ -28,7 +28,7 @@ using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using BH.oM.Geometry;
 using System.Drawing;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 
 namespace BH.UI.Grasshopper
 {

--- a/Grasshopper_UI/Render/RenderMeshes.cs
+++ b/Grasshopper_UI/Render/RenderMeshes.cs
@@ -20,7 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using BHG = BH.oM.Geometry;
 using RHG = Rhino.Geometry;
 using Rhino.Display;

--- a/Grasshopper_UI/Render/RenderRhinoMeshes.cs
+++ b/Grasshopper_UI/Render/RenderRhinoMeshes.cs
@@ -28,7 +28,7 @@ using BH.oM.Base.Attributes;
 using System.Collections.Generic;
 using BH.oM.Geometry;
 using System.Drawing;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 
 namespace BH.UI.Grasshopper
 {

--- a/Grasshopper_UI/Render/RenderRhinoWires.cs
+++ b/Grasshopper_UI/Render/RenderRhinoWires.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using GH = Grasshopper;
 using BH.oM.Base;
 using BH.oM.Geometry;
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 
 namespace BH.UI.Grasshopper
 { 

--- a/Grasshopper_UI/Render/RenderWires.cs
+++ b/Grasshopper_UI/Render/RenderWires.cs
@@ -20,7 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Rhinoceros;
+using BH.Engine.Adapters.Rhinoceros;
 using BHG = BH.oM.Geometry;
 using RHG = Rhino.Geometry;
 using Grasshopper.Kernel;


### PR DESCRIPTION

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on https://github.com/BHoM/Rhinoceros_Toolkit/pull/249
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->


<!-- Add short description of what has been fixed -->
Changed namespace for `BH.Engine.Rhinoceros` to `BH.Engine.Adapters.Rhinoceros`

