### PR TITLE
Fix missing internalised data when method component is versioned

### DIFF
--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -38,6 +38,7 @@ using System.Collections;
 using BH.Adapter;
 using BH.oM.Base.Debugging;
 using BH.UI.Base;
+using Grasshopper.Kernel.Types;
 
 namespace BH.UI.Grasshopper.Templates
 {
@@ -135,6 +136,9 @@ namespace BH.UI.Grasshopper.Templates
                 newParam.DataMapping = oldParam.DataMapping;
                 newParam.Simplify = oldParam.Simplify;
                 newParam.Reverse = oldParam.Reverse;
+
+                if (oldParam.GetType() == newParam.GetType())
+                    TransferPersistentData(oldParam as dynamic, newParam as dynamic);
 
                 Params.UnregisterInputParameter(oldParam);
                 Params.RegisterInputParam(newParam, index);
@@ -252,6 +256,13 @@ namespace BH.UI.Grasshopper.Templates
                 target.AddSource(newParam);
 
             oldParam.IsolateObject();
+        }
+
+        /*******************************************/
+
+        protected virtual void TransferPersistentData<T>(GH_PersistentParam<T> oldParam, GH_PersistentParam<T> newParam) where T : class, IGH_Goo
+        {
+            newParam.SetPersistentData(oldParam.PersistentData);
         }
 
         /*******************************************/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #647 



### Test files

#### Step 1
Create a Point component (the one from the method):
![image](https://github.com/BHoM/Grasshopper_UI/assets/16853390/4dfed331-d1af-4001-8ad2-e6b9d5248ddf)

#### Step 2
Internalise some data in the x input parameter and save the file:
![image](https://github.com/BHoM/Grasshopper_UI/assets/16853390/bf1ca226-5434-4d73-b57c-dfe836f8a84a)

#### Step 3
Edit the code for the Create.Point method like so (i.e. change the first input to `a`):
![image](https://github.com/BHoM/Grasshopper_UI/assets/16853390/b01d2663-0d1c-485d-a566-1253c66a3874)

#### Step 4
Recompile the `BHoM_Engine` **and** the `Versioning_Toolkit`


#### Step 5
Re=open the file and make sure that the internalised data is still there:
![image](https://github.com/BHoM/Grasshopper_UI/assets/16853390/7f336d9e-ddde-471f-b5d2-f554e3f903d3)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->