### PR TITLE
Fix Rhino8 Crash With Analytics PopUp

### DIFF
--- a/Grasshopper_UI/CallerComponent/GH_Component.cs
+++ b/Grasshopper_UI/CallerComponent/GH_Component.cs
@@ -128,7 +128,7 @@ namespace BH.UI.Grasshopper.Templates
             if (DA.Iteration == 0)
             {
                 GH_Document doc = GH.Instances.ActiveCanvas.Document;
-                Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, InstanceGuid, Caller.GetType().Name, Caller.SelectedItem, events, doc.CanvasID(), doc.FilePath);
+                Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, GH.Instances.DocumentEditor.ProductVersion, InstanceGuid, Caller.GetType().Name, Caller.SelectedItem, events, doc.CanvasID(), doc.FilePath);
             }
                 
         }

--- a/Grasshopper_UI/Templates/CallerValueList.cs
+++ b/Grasshopper_UI/Templates/CallerValueList.cs
@@ -145,7 +145,7 @@ namespace BH.UI.Grasshopper.Templates
             }
 
             GH_Document doc = GH.Instances.ActiveCanvas.Document;
-            Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, InstanceGuid, Caller.GetType().Name, Caller.SelectedItem, null, doc.CanvasID(), doc.FilePath);
+            Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, GH.Instances.DocumentEditor.ProductVersion, InstanceGuid, Caller.GetType().Name, Caller.SelectedItem, null, doc.CanvasID(), doc.FilePath);
         }
 
         /*******************************************/


### PR DESCRIPTION
### Issues addressed by this PR

Related to https://github.com/BuroHappoldEngineering/BuroHappold_BHoMAnalytics_Toolkit/pull/67

![Issue Sorted - GH View](https://github.com/user-attachments/assets/04bb1876-800f-4985-8adf-d1d4137d88c6)

![Issue Sorted - ROBOT View](https://github.com/user-attachments/assets/9a3c8adb-47dd-4b5c-82b0-4be5935fb114)

Preventing the Analytics PopUp Window from popping up, Rhino8 doesn't crash anymore and it's possible to use the BHoM with Rhino8 models. In screenshots above, example of pull from Robot Model in Rhino 8 via the BHoM - all working fine.


### Test files
Grasshopper File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoMAnalytics_Toolkit/%2366-FixRhino8CrashWithAnalyticsPopUp/Test%20Script.gh?csf=1&web=1&e=Ydog48
Robot File
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoMAnalytics_Toolkit/%2366-FixRhino8CrashWithAnalyticsPopUp/[TestRobotModel.rtd](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoMAnalytics_Toolkit/%2366-FixRhino8CrashWithAnalyticsPopUp/TestRobotModel.rtd?csf=1&web=1&e=xIGmF5)?csf=1&web=1&e=xIGmF5


### Changelog
- Prevent Analytics Window from popping up