### PR TITLE
Add Unittest component from component functionality

### DIFF
--- a/Grasshopper_UI/CallerComponent/GH_Component.cs
+++ b/Grasshopper_UI/CallerComponent/GH_Component.cs
@@ -140,6 +140,34 @@ namespace BH.UI.Grasshopper.Templates
         {
             base.AppendAdditionalComponentMenuItems(menu);
             Caller.AddToMenu(menu);
+
+            if (SubCategory == "Engine")
+            {
+                menu.Items.Add(new ToolStripSeparator());
+                menu.Items.Add(new ToolStripMenuItem("Add unittest component", null, (sender, e) =>
+                {
+                    GH_Document doc = GH.Instances.ActiveCanvas.Document;
+                    if (doc != null)
+                    {
+                        UnitTestComponent unitTestComponent = new UnitTestComponent();
+                        unitTestComponent.Caller.SetItem(Caller.SelectedItem);
+                        doc.AddObject(unitTestComponent, false);
+                        for(int i = 0; i < this.Params.Input.Count; i++)
+                        {
+                            if (this.Params.Input[i].SourceCount > 0)
+                            {
+                                var sources = this.Params.Input[i].Sources;
+                                foreach (var source in sources)
+                                {
+                                    unitTestComponent.Params.Input[i].AddSource(source);
+                                }
+                            }
+                        }
+                        unitTestComponent.Attributes.Pivot = new System.Drawing.PointF(Attributes.Pivot.X +200, Attributes.Pivot.Y);
+                        unitTestComponent.ExpireSolution(true);
+                    }
+                }));
+            }
         }
 
         /*******************************************/


### PR DESCRIPTION

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #760 

<!-- Add short description of what has been fixed -->

Adds initial code for creating a unit-test component based on a in-place component on the canvas in Grasshopper.

Please see issue for a bit more details, but this would essentially allow for more rapidly turning well working test-scripts into datadriven unit-tests (dataset unit tests).

The code in this PR is not suitable for merge atm, but just a proof of concept. Still needs to be figured out:
- Which components should this apply to (think the "Engine" category filtering is not cutting it)
- Do we want this to be included in deployed installers (cant really see the downside to it, bu could argue it should not)
- The code needs to be more properly formated into its own method etc. Again, this is just a working proof of concept.

Not to be merged before the 9.3 release.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->